### PR TITLE
Check for availability of tskill before using taskkill

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ func init() {
 	restartThreshold = time.Duration(idleMinutes) * time.Minute
 	logDebug("idletime = " + restartThreshold.String())
 
-	ipAddress := GetOutboundIP().String()
+	ipAddress := getOutboundIP().String()
 	logInfo("Your IP address is %s", ipAddress)
 
 	logDebug("Startup successful")

--- a/main.go
+++ b/main.go
@@ -148,7 +148,7 @@ func monitorAndRestartProcess() {
 			if isCommandAvailable("tskill") {
 				killCmd = exec.Command("tskill", strconv.Itoa(processID))
 			} else {
-				killCmd = exec.Command("taskkill", "/F", "/PID", strconv.Itoa(processID))
+				killCmd = exec.Command("taskkill", "/F", "/T", "/PID", strconv.Itoa(processID))
 			}
 
 			stdout, err := killCmd.CombinedOutput()

--- a/main.go
+++ b/main.go
@@ -165,7 +165,7 @@ func monitorAndRestartProcess() {
 }
 
 func getOutboundIP() net.IP {
-	// Destination here does not matter for UDP
+	// Destination here must be a valid one else it may give a loopback agddress
 	conn, err := net.Dial("udp", "8.8.8.8:80")
 	if err != nil {
 		log.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ func init() {
 	restartThreshold = time.Duration(idleMinutes) * time.Minute
 	logDebug("idletime = " + restartThreshold.String())
 
-	ipAddress := getOutboundIP().String()
+	ipAddress := GetOutboundIP().String()
 	logInfo("Your IP address is %s", ipAddress)
 
 	logDebug("Startup successful")
@@ -166,7 +166,7 @@ func monitorAndRestartProcess() {
 
 func getOutboundIP() net.IP {
 	// Destination here does not matter for UDP
-	conn, err := net.Dial("udp", "0.0.0.0:0")
+	conn, err := net.Dial("udp", "8.8.8.8:80")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This commit checks if `tskill` is available before using it to kill a process. If `tskill` is not found, it falls back to `taskkill` to ensure the process is terminated. 

Additionally, a bug is fixed where the outbound address may be incorrectly set to the loopback address (127.0.0.1) due to an invalid UDP destination, ensuring the valid destination address is now used.
